### PR TITLE
Pure Components

### DIFF
--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -20,7 +20,7 @@ export type ViewWrapperProps<M> = {
  * This component looks for `execContext` in its parent context, and propagates
  * itself with `execContext` in its children's contexts.
  */
-export default class ViewWrapper<M> extends React.Component<ViewWrapperProps<M>, any> {
+export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps<M>, any> {
 
   public static contextTypes = { execContext: PropTypes.object };
 


### PR DESCRIPTION
Taking advantage of `Pure Components` as opposed to `Components`